### PR TITLE
Add the Bearer Auth Security Scheme to the OpenAPI Documentation

### DIFF
--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -465,3 +465,5 @@ components:
         type:
           type: string
           description: enumerated type, as listed in https://spaces.at.internet2.edu/display/COmanage/Recommendations+For+Email+Addresses
+security:
+  - bearerAuth: []

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -294,6 +294,11 @@ components:
         'application/json':
           schema:
             $ref: "#/components/schemas/ServiceRegistration"
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
     ServiceVerificationTokenRequest:
       content:
         'application/json':

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -298,7 +298,6 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
     ServiceVerificationTokenRequest:
       content:
         'application/json':


### PR DESCRIPTION
This will add documentation to the OpenAPI docs to indicate that all AuthZ requests accept an Authorization Bearer Token. The Swagger UI will allow us to add a token to all requests.
