### PR TITLE
Accept different tokens from different services' OIDC clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,42 +11,6 @@ Before running the `run.sh` script, open the file `secrets.sh.example` and renam
 
 The `run.sh` script will use the environment variables listed in `secrets.sh` and launch three docker containers. The API server will be available at http://localhost:1235.
 
-## Overview
-The authorization service allows PCGL to separately manage OIDC tokens and clients for different services while still using CILogon/COManage to handle authentication and user roles and groups.
-
-The authorization service manages policy decisions about user access for registered services as well.
-
-PCGL services will register with the authorization service. Registration allows authz to:
-* designate actions allowed for users and user groups, based on study
-* designate an OIDC client that will be the issuer of its user tokens
-* allows the authz service to verify that any authz call is coming from a known registered service.
-
-## Registering a service
-
-To register a service, a site admin will need to send a POST to the `/authz/service` endpoint with a request body similar to:
-```
-{
-  "service_id": "fakeservice",
-  "authorization": {
-    "client_id": "cilogon:/client_id/11e718dfc4d68f1b34731d913294d26b"
-  },
-  "editable": [
-    {
-      "method": "POST",
-      "endpoint": "fake/submit/?.*"
-    }
-  ],
-  "readable": [
-    {
-      "method": "GET",
-      "endpoint": "fake/?.*"
-    }
-  ]
-}
-```
-This call needs to be sent with a bearer token from a site administrator.
-
-
 ## Calling the REST API
 
 The authz API is primarily meant to be called by registered services. While all calls require a bearer token that is associated with a user in CILogon, service calls additionally require `X-Service-Id` and `X-Service-Token` headers to determine which service's OIDC client is being used for the user token.

--- a/app/permissions_engine/authz.rego
+++ b/app/permissions_engine/authz.rego
@@ -23,7 +23,6 @@ allow if {
 # The authx library uses these paths:
 authx_paths := {
 	"permissions": ["v1", "data", "permissions"],
-	"user_id": ["v1", "data", "idp", "user_key"],
 }
 
 # An authorized user has a valid token (and passes in that same token for both bearer and body)

--- a/app/permissions_engine/idp.rego
+++ b/app/permissions_engine/idp.rego
@@ -9,7 +9,8 @@ user_info := output if {
 	output := http.send({"method": "get", "url": concat("", ["https://cilogon.org/oauth2/userinfo?access_token=", input[possible_tokens[_]]])}).body
 }
 
-user_key := user_info.sub
+user_sub := user_info.sub
+user_aud := user_info.aud
 
 default valid_token := false
-valid_token if user_key
+valid_token if user_sub

--- a/app/permissions_engine/permissions.rego
+++ b/app/permissions_engine/permissions.rego
@@ -15,6 +15,8 @@ site_admin := data.calculate.site_admin if {
 	valid_token
 }
 
+else := false
+
 site_curator := data.calculate.site_curator if {
 	valid_token
 }
@@ -99,6 +101,8 @@ else := false
 
 user_id := data.vault.user_id
 user_pcglid := data.vault.user_pcglid
+user_aud := data.idp.user_aud
+user_sub := data.idp.user_sub
 
 #
 # Debugging information for decision log

--- a/app/permissions_engine/vault.rego
+++ b/app/permissions_engine/vault.rego
@@ -22,7 +22,7 @@ study_auths[p] := study if {
 
 user_index := http.send({"method": "get", "url": "VAULT_URL/v1/opa/users/index", "headers": {"X-Vault-Token": vault_token}, "raise_error": false}).body.data
 
-user_id := user_index[data.idp.user_key] if {
+user_id := user_index[data.idp.user_sub] if {
 	not input.body.user_pcglid
 }
 

--- a/app/renew_token.sh
+++ b/app/renew_token.sh
@@ -6,10 +6,13 @@ export KEY_ROOT=$(tail -n 1 /vault/config/keys.txt)
 
 echo "renewing approle token"
 curl --request POST --header "X-Vault-Token: ${VAULT_APPROLE_TOKEN}" $VAULT_URL/v1/auth/token/renew-self > finish.json
+cat finish.json | jq
 grep "error" finish.json
 if [[ $? -eq 0 ]]; then
     echo "creating approle token"
+    date
     echo "{\"id\": \"${VAULT_APPROLE_TOKEN}\", \"policies\": [\"approle\"], \"periodic\": \"24h\"}" > token.json
-    curl --request POST --header "X-Vault-Token: ${KEY_ROOT}" --data @token.json $VAULT_URL/v1/auth/token/create/approle
+    curl --request POST --header "X-Vault-Token: ${KEY_ROOT}" --data @token.json $VAULT_URL/v1/auth/token/create/approle > finish.json
+    cat finish.json | jq
 fi
 rm finish.json

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==6.0.1
-requests==2.32.2
+requests==2.32.4
 requests-mock>=1.12.1
 connexion==3.1.0
 connexion[swagger-ui]

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -45,15 +45,13 @@ def get_auth_token(request, token=None):
 # General authorization methods
 ######
 
-def get_opa_permissions(bearer_token=None, user_token=None, user_pcglid=None, method=None, path=None, study=None):
-    token = get_auth_token(None, token=bearer_token)
-    if user_token is None:
-        user_token = token
+def get_opa_permissions(request=None, user_pcglid=None, method=None, path=None, study=None, assume_site_admin=False):
+    token = get_auth_token(request)
     headers = {
         "Authorization": f"Bearer {token}"
     }
     input = {
-        "token": user_token,
+        "token": token,
         "body": {
             "method": method,
             "path": path
@@ -68,25 +66,53 @@ def get_opa_permissions(bearer_token=None, user_token=None, user_pcglid=None, me
         headers=headers,
         json={"input": input}
         )
+    if response.status_code == 401:
+        return {"error": "User token is not valid"}, 401
+
+    ### Authorization control: only registered users
     if response.status_code == 200:
-        return response.json()["result"], 200
+        permissions = response.json()["result"]
+
+        # if this request is to check for site admin, just return here
+        if assume_site_admin:
+            return permissions, 200
+
+        # check to see if the request has the needed headers:
+        try:
+            if "X-Service-Id" not in request.headers:
+                raise AuthzError("no service id in headers")
+
+            if "X-Service-Token" not in request.headers:
+                raise AuthzError("no service token in headers")
+        except AuthzError as e:
+            return {"error": f"Service headers incorrect: {str(e)}"}, 400
+
+        # check to see if this is from a registered service:
+        service_dict, status_code = get_service(request.headers['X-Service-Id'])
+        if status_code != 200:
+            return {"error": f"no service registered as {request.headers['X-Service-Id']}"}, 400
+        if not verify_service_token(service=request.headers['X-Service-Id'], token=request.headers['X-Service-Token'], service_uuid=service_dict["service_uuid"]):
+            return {"error": "Service token is not valid"}, 403
+        client_id = service_dict["authorization"]["client_id"]
+        if "user_aud" in permissions and client_id == permissions["user_aud"]:
+            return permissions, 200
+        return {"error": f"user token not issued by {request.headers['X-Service-Id']}"}, 403
+
     return response.text, response.status_code
 
 
-def get_authorized_studies(request, token=None):
+def get_authorized_studies(request):
     """
     Get studies authorized for the user.
     Returns array of strings
     """
-
-    token = get_auth_token(request, token=token)
 
     if hasattr(request, 'path'):
         path = request.path
     elif hasattr(request, 'url'):
         path = request.url
 
-    response, status_code = get_opa_permissions(bearer_token=token, method=request.method, path=path)
+    response, status_code = get_opa_permissions(request=request, method=request.method, path=path, assume_site_admin=True)
     if status_code == 200:
         if "studies" in response:
             return response["studies"], 200
@@ -94,14 +120,12 @@ def get_authorized_studies(request, token=None):
     return [], status_code
 
 
-def is_site_admin(request, token=None):
+def is_site_admin(request):
     """
     Is the user associated with the token a site admin?
     Returns boolean.
     """
-    token = get_auth_token(request, token=token)
-
-    response, status_code = get_opa_permissions(bearer_token=token)
+    response, status_code = get_opa_permissions(request=request, assume_site_admin=True)
 
     if status_code == 200:
         if 'site_admin' in response:
@@ -109,40 +133,25 @@ def is_site_admin(request, token=None):
     return False
 
 
-def is_action_allowed_for_study(request, token=None, method=None, path=None, study=None):
+def is_action_allowed_for_study(request, method=None, path=None, study=None):
     """
     Is the user allowed to perform this action on this study?
     """
-    token = get_auth_token(request, token=token)
-
-    response, status_code = get_opa_permissions(bearer_token=token, method=method, path=path, study=study)
+    response, status_code = get_opa_permissions(request=request, method=method, path=path, study=study, assume_site_admin=True)
     if status_code == 200:
         if 'allowed' in response:
             return response["allowed"]
     return False
 
 
-def get_oidcsub(request, token=None):
+def get_oidcsub(request):
     """
     Returns the OIDC sub (as defined in the sub claim of userinfo).
     """
-    token = get_auth_token(request, token=token)
-    headers = {
-        "Authorization": f"Bearer {token}"
-    }
-    response = requests.post(
-        OPA_URL + f"/v1/data/idp/user_key",
-        headers=headers,
-        json={
-            "input": {
-                    "token": token
-                }
-            }
-        )
-    if response.status_code == 200:
-        if 'result' in response.json():
-            return response.json()['result']
-    return None
+    response, status_code = get_opa_permissions(request=request)
+    if status_code == 200:
+        return response['user_sub'], status_code
+    return response, status_code
 
 
 #####
@@ -172,8 +181,10 @@ def get_user_by_comanage_id(comanage_id):
     return get_service_store_secret("opa", key=f"users/{comanage_id}")
 
 
-def get_self(request, token=None):
-    oidcsub = get_oidcsub(request, token=token)
+def get_self(request):
+    oidcsub, status_code = get_oidcsub(request)
+    if status_code != 200:
+        return oidcsub, status_code
     user_index, status_code = get_service_store_secret("opa", key=f"users/index")
     if status_code == 200:
         if oidcsub in user_index:
@@ -624,10 +635,10 @@ def get_user_record(comanage_id=None, oidcsub=None, force=False):
     return response, status_code
 
 
-def get_comanage_user(request, token=None, oidcsub=None):
+def get_comanage_user(request, oidcsub=None):
     if oidcsub is None:
-        oidcsub = get_oidcsub(request, token=token)
-    if oidcsub is not None:
+        oidcsub, status_code = get_oidcsub(request)
+    if status_code == 200:
         response = requests.get(f"{PCGL_API_URL}/api/co/{PCGL_COID}/core/v1/people", params={"identifier": oidcsub}, auth=(PCGL_CORE_API_USER, PCGL_CORE_API_KEY))
         if response.status_code == 200:
             return response.json()[0], 200

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -130,6 +130,8 @@ def is_site_admin(request):
     if status_code == 200:
         if 'site_admin' in response:
             return response["site_admin"]
+    if status_code == 401:
+        raise AuthzError("User token is invalid")
     return False
 
 
@@ -645,7 +647,7 @@ def get_comanage_user(request, oidcsub=None):
         if response.status_code == 200:
             return response.json()[0], 200
         return response.text, response.status_code
-    return {"error": "could not find oidcsub"}, 500
+    return oidcsub, status_code
 
 
 def get_comanage_groups():

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -135,6 +135,9 @@ paths:
                     type: string
                     description: service token
   /study:
+    parameters:
+      - $ref: "#/components/parameters/ServiceId"
+      - $ref: "#/components/parameters/ServiceToken"
     post:
       summary: Add authorization information for a study
       description: Add authorization information for a study
@@ -163,6 +166,8 @@ paths:
                   $ref: '#/components/schemas/StudyAuthorization'
   /study/{study_id}:
     parameters:
+      - $ref: "#/components/parameters/ServiceId"
+      - $ref: "#/components/parameters/ServiceToken"
       - in: path
         name: study_id
         schema:
@@ -191,6 +196,8 @@ paths:
                 $ref: '#/components/schemas/StudyAuthorization'
   /user/lookup:
     parameters:
+      - $ref: "#/components/parameters/ServiceId"
+      - $ref: "#/components/parameters/ServiceToken"
       - in: query
         name: email
         schema:
@@ -211,6 +218,8 @@ paths:
                   type: object
   /user/{pcgl_id}:
     parameters:
+      - $ref: "#/components/parameters/ServiceId"
+      - $ref: "#/components/parameters/ServiceToken"
       - in: path
         name: pcgl_id
         schema:
@@ -248,6 +257,8 @@ paths:
                 $ref: '#/components/schemas/UserAuthorization'
   /user/{pcgl_id}/study/{study_id}:
     parameters:
+      - $ref: "#/components/parameters/ServiceId"
+      - $ref: "#/components/parameters/ServiceToken"
       - in: path
         name: pcgl_id
         schema:
@@ -281,6 +292,9 @@ paths:
               schema:
                 type: object
   /allowed:
+    parameters:
+      - $ref: "#/components/parameters/ServiceId"
+      - $ref: "#/components/parameters/ServiceToken"
     post:
       summary: Is the authorized user allowed to perform the requested action?
       description: Returns whether a user is allowed to perform the requested action on the specified datasets
@@ -310,6 +324,21 @@ components:
       type: http
       scheme: bearer
       x-bearerInfoFunc: authz_operations.handle_token
+  parameters:
+    ServiceId:
+      in: header
+      name: X-Service-Id
+      required: true
+      schema:
+        type: string
+      description: ID of a registered service
+    ServiceToken:
+      in: header
+      name: X-Service-Token
+      required: true
+      schema:
+        type: string
+      description: service token created for the service specified by X-Service-Id
   requestBodies:
     ServiceRegistrationRequest:
       content:

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -6,6 +6,8 @@ info:
 servers:
   - url: http://localhost:1235/authz
   - url: /authz
+security:
+  - bearerAuth: []
 paths:
   /service-info:
     get:
@@ -303,6 +305,11 @@ paths:
           description: Success
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      x-bearerInfoFunc: authz_operations.handle_token
   requestBodies:
     ServiceRegistrationRequest:
       content:

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -227,6 +227,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/UserAuthorization'
+        401:
+          description: User token is invalid
+        403:
+          description: Service token is invalid
     post:
       summary: Add a study authorization for a user
       description: Authorize a study for a user (or update a study auth for a user)

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -129,7 +129,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  result:
+                  token:
                     type: string
                     description: service token
   /study:

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -127,7 +127,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceRegistration'
+                type: object
+                properties:
+                  result:
+                    type: string
+                    description: service token
   /study:
     post:
       summary: Add authorization information for a study
@@ -345,6 +349,7 @@ components:
         - service_id
         - readable
         - editable
+        - authorization
       properties:
         service_id:
           type: string
@@ -359,6 +364,14 @@ components:
           description: Actions that allow a user to edit and delete data
           items:
             $ref: "#/components/schemas/Action"
+        authorization:
+          type: object
+          description: Information about the OIDC client associated with the service. This information is required to be submitted when registering a service, but will not be returned on GET requests for security reasons.
+          required:
+            - client_id
+          properties:
+            client_id:
+              type: string
     StudyAuthorization:
       type: object
       description: study and the researchers involved in this study

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -7,6 +7,7 @@ import auth
 import config
 import uuid
 import json
+import requests
 
 
 app = connexion.AsyncApp(__name__)
@@ -22,6 +23,12 @@ def get_headers():
     headers["Content-Type"] = "application/json"
     return headers
 
+
+def handle_token(token):
+    response = requests.get(url="https://cilogon.org/oauth2/userinfo", params={"access_token": token}, allow_redirects=False)
+    if response.status_code == 200:
+        return response.json()
+    raise connexion.exceptions.Unauthorized(response.text)
 
 # API endpoints
 def get_service_info():

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -58,6 +58,10 @@ def list_group(group_id):
                 return result, 200
             return groups, status_code
         return {"error": "User is not authorized to list groups"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -71,8 +75,10 @@ def list_services():
         if auth.is_site_admin(connexion.request):
             return auth.list_services()
         return {"error": "User is not authorized to list services"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
-        return {"error": str(e)}, 403
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -83,8 +89,10 @@ async def add_service():
         if auth.is_site_admin(connexion.request):
             return auth.add_service(service)
         return {"error": "User is not authorized to add services"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
-        return {"error": str(e)}, 403
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -101,8 +109,10 @@ def get_service(service_id):
             else:
                 return {"error": "No service found"}, 404
         return {"error": "User is not authorized to get services"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
-        return {"error": str(e)}, 403
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -113,8 +123,10 @@ def remove_service(service_id):
         if auth.is_site_admin(connexion.request):
             return auth.remove_service(service_id)
         return {"error": "User is not authorized to remove services"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
-        return {"error": str(e)}, 403
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -131,8 +143,10 @@ async def create_service_token(service_id):
             token = auth.create_service_token(service_uuid)
             return {"token": token}, 200
         return {"error": "Could not find service"}, 404
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
-        return {"error": str(e)}, 403
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -143,6 +157,10 @@ def verify_service_token(service_id):
         if "X-Service-Token" in connexion.request.headers:
             return {"result": auth.verify_service_token(service_id, connexion.request.headers["X-Service-Token"])}
         return {"error": "no X-Service-Token present"}, 500
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -157,6 +175,10 @@ def list_study_authorizations():
             response, status_code = auth.list_studies()
             return response, status_code
         return {"error": "User is not authorized to list studies"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -168,6 +190,10 @@ async def add_study_authorization():
             response, status_code = auth.add_study(study)
             return response, status_code
         return {"error": "User is not authorized to add studies"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -179,6 +205,10 @@ def get_study_authorization(study_id):
             response, status_code = auth.get_study(study_id)
             return response, status_code
         return {"error": "User is not authorized to get studies"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -190,6 +220,10 @@ def remove_study_authorization(study_id):
             response, status_code = auth.remove_study(study_id)
             return response, 200
         return {"error": "User is not authorized to remove studies"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -200,39 +234,44 @@ def remove_study_authorization(study_id):
 
 @app.route('/user/<path:pcgl_id>')
 def list_authz_for_user(pcgl_id):
-    if pcgl_id == "me":
-        user_dict, status_code = auth.get_self(connexion.request)
-    else:
-        user_dict, status_code = auth.get_user_by_pcglid(pcgl_id)
-    if status_code == 200:
-        # sync with COManage:
-        auth.get_user_record(comanage_id=user_dict["comanage_id"], force=True)
-        result = {
-            "userinfo": {
-                "emails": user_dict["emails"],
-                "pcgl_id": user_dict["pcglid"]
-            },
-            "study_authorizations": {
-            },
-            "dac_authorizations": list(user_dict["study_authorizations"].values())
-        }
-        permissions, status_code = auth.get_opa_permissions(request=connexion.request, user_pcglid=user_dict["pcglid"], method=None, path=None, study=None)
-        if status_code == 200:
-            result["study_authorizations"]["editable_studies"] = permissions["editable_studies"]
-            result["study_authorizations"]["readable_studies"] = permissions["readable_studies"]
-            result["userinfo"]["site_admin"] = permissions["user_is_site_admin"]
-            result["userinfo"]["site_curator"] = permissions["user_is_site_curator"]
+    try:
+        if pcgl_id == "me":
+            user_dict, status_code = auth.get_self(connexion.request)
         else:
-            return permissions, status_code
-        result["groups"] = []
-        groups, status_code = auth.get_service_store_secret("opa", key="groups")
+            user_dict, status_code = auth.get_user_by_pcglid(pcgl_id)
         if status_code == 200:
-            for group_id in groups["index"]:
-                group = groups["index"][str(group_id)]
-                members = group.pop("members")
-                if user_dict["comanage_id"] in members:
-                    result["groups"].append(group)
-        return result, status_code
+            # sync with COManage:
+            auth.get_user_record(comanage_id=user_dict["comanage_id"], force=True)
+            result = {
+                "userinfo": {
+                    "emails": user_dict["emails"],
+                    "pcgl_id": user_dict["pcglid"]
+                },
+                "study_authorizations": {
+                },
+                "dac_authorizations": list(user_dict["study_authorizations"].values())
+            }
+            permissions, status_code = auth.get_opa_permissions(request=connexion.request, user_pcglid=user_dict["pcglid"], method=None, path=None, study=None)
+            if status_code == 200:
+                result["study_authorizations"]["editable_studies"] = permissions["editable_studies"]
+                result["study_authorizations"]["readable_studies"] = permissions["readable_studies"]
+                result["userinfo"]["site_admin"] = permissions["user_is_site_admin"]
+                result["userinfo"]["site_curator"] = permissions["user_is_site_curator"]
+            else:
+                return permissions, status_code
+            result["groups"] = []
+            groups, status_code = auth.get_service_store_secret("opa", key="groups")
+            if status_code == 200:
+                for group_id in groups["index"]:
+                    group = groups["index"][str(group_id)]
+                    members = group.pop("members")
+                    if user_dict["comanage_id"] in members:
+                        result["groups"].append(group)
+            return result, status_code
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     return user_dict, status_code
 
 
@@ -257,6 +296,10 @@ async def authorize_study_for_user(pcgl_id):
                 return response, status_code
             return user_dict, status_code
         return {"error": "User is not authorized to authorize studies"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -273,6 +316,10 @@ def get_study_for_user(pcgl_id, study_id):
                     return user_dict["study_authorizations"][p], 200
             return {"error": f"No study {study_id} found for user"}, status_code
         return {"error": "User is not authorized to get studies"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -291,6 +338,10 @@ def remove_study_for_user(pcgl_id, study_id):
                     return list(response["study_authorizations"].values()), status_code
             return {"error": f"No study {study_id} found for user"}, status_code
         return {"error": "User is not authorized to delete studies"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -307,6 +358,10 @@ def lookup_user(email=None):
                         result.append(user["pcglid"])
             return result, status_code
         return {"error": "User is not authorized to look up users"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -321,16 +376,24 @@ async def is_allowed():
             return result, 200
         else:
             return auth.is_action_allowed_for_study(connexion.request, action_dict["action"]["method"], path=action_dict["action"]["endpoint"]), 200
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
+    except auth.AuthzError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
-            return {"error": f"{type(e)} {str(e)}"}, 500
+        return {"error": f"{type(e)} {str(e)}"}, 500
 
 
 async def reload_comanage():
     try:
         if not auth.is_site_admin(connexion.request):
             return {"error": "User is not authorized to reload COManage"}, 403
+    except auth.UserTokenError as e:
+        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
-        return {"error": str(e)}, 403
+        return {"error": f"{type(e)} {str(e)}"}, 403
+    except Exception as e:
+        return {"error": f"{type(e)} {str(e)}"}, 500
     result, status_code = auth.reload_comanage()
     print(result)
     return result, status_code

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -208,13 +208,14 @@ def list_authz_for_user(pcgl_id):
             },
             "dac_authorizations": list(user_dict["study_authorizations"].values())
         }
-        token = auth.get_auth_token(connexion.request)
-        permissions, status_code = auth.get_opa_permissions(bearer_token=token, user_pcglid=user_dict["pcglid"], method=None, path=None, study=None)
+        permissions, status_code = auth.get_opa_permissions(request=connexion.request, user_pcglid=user_dict["pcglid"], method=None, path=None, study=None)
         if status_code == 200:
             result["study_authorizations"]["editable_studies"] = permissions["editable_studies"]
             result["study_authorizations"]["readable_studies"] = permissions["readable_studies"]
             result["userinfo"]["site_admin"] = permissions["user_is_site_admin"]
             result["userinfo"]["site_curator"] = permissions["user_is_site_curator"]
+        else:
+            return permissions, status_code
         result["groups"] = []
         groups, status_code = auth.get_service_store_secret("opa", key="groups")
         if status_code == 200:

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -92,6 +92,7 @@ def get_service(service_id):
             service, status_code = auth.get_service(service_id)
             if status_code < 300:
                 service.pop("service_uuid")
+                service.pop("authorization")
                 return service, 200
             else:
                 return {"error": "No service found"}, 404

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -143,8 +143,6 @@ async def create_service_token(service_id):
             token = auth.create_service_token(service_uuid)
             return {"token": token}, 200
         return {"error": "Could not find service"}, 404
-    except auth.UserTokenError as e:
-        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
         return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:
@@ -157,8 +155,6 @@ def verify_service_token(service_id):
         if "X-Service-Token" in connexion.request.headers:
             return {"result": auth.verify_service_token(service_id, connexion.request.headers["X-Service-Token"])}
         return {"error": "no X-Service-Token present"}, 500
-    except auth.UserTokenError as e:
-        return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:
         return {"error": f"{type(e)} {str(e)}"}, 403
     except Exception as e:

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -124,15 +124,13 @@ async def create_service_token(service_id):
     service = await connexion.request.json()
     service_uuid = service["service_uuid"]
     try:
-        if auth.is_site_admin(connexion.request):
-            service_dict, status_code = auth.get_service(service_id)
-            if status_code == 200:
-                if service_dict["service_uuid"] != service_uuid:
-                    return {"error": f"Service UUID does not match service name"}
-                token = auth.create_service_token(service_uuid)
-                return {"token": token}, 200
-            return {"error": "Could not find service"}, 404
-        return {"error": "User is not authorized to create verification tokens"}, 403
+        service_dict, status_code = auth.get_service(service_id)
+        if status_code == 200:
+            if service_dict["service_uuid"] != service_uuid:
+                return {"error": f"Service UUID does not match service name"}
+            token = auth.create_service_token(service_uuid)
+            return {"token": token}, 200
+        return {"error": "Could not find service"}, 404
     except auth.AuthzError as e:
         return {"error": str(e)}, 403
     except Exception as e:

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -71,6 +71,8 @@ def list_services():
         if auth.is_site_admin(connexion.request):
             return auth.list_services()
         return {"error": "User is not authorized to list services"}, 403
+    except auth.AuthzError as e:
+        return {"error": str(e)}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -81,6 +83,8 @@ async def add_service():
         if auth.is_site_admin(connexion.request):
             return auth.add_service(service)
         return {"error": "User is not authorized to add services"}, 403
+    except auth.AuthzError as e:
+        return {"error": str(e)}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -97,6 +101,8 @@ def get_service(service_id):
             else:
                 return {"error": "No service found"}, 404
         return {"error": "User is not authorized to get services"}, 403
+    except auth.AuthzError as e:
+        return {"error": str(e)}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -107,6 +113,8 @@ def remove_service(service_id):
         if auth.is_site_admin(connexion.request):
             return auth.remove_service(service_id)
         return {"error": "User is not authorized to remove services"}, 403
+    except auth.AuthzError as e:
+        return {"error": str(e)}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -125,6 +133,8 @@ async def create_service_token(service_id):
                 return {"token": token}, 200
             return {"error": "Could not find service"}, 404
         return {"error": "User is not authorized to create verification tokens"}, 403
+    except auth.AuthzError as e:
+        return {"error": str(e)}, 403
     except Exception as e:
         return {"error": f"{type(e)} {str(e)}"}, 500
 
@@ -318,9 +328,11 @@ async def is_allowed():
 
 
 async def reload_comanage():
-    if not auth.is_site_admin(connexion.request):
-        return {"error": "User is not authorized to reload COManage"}, 403
-
+    try:
+        if not auth.is_site_admin(connexion.request):
+            return {"error": "User is not authorized to reload COManage"}, 403
+    except auth.AuthzError as e:
+        return {"error": str(e)}, 403
     result, status_code = auth.reload_comanage()
     print(result)
     return result, status_code

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,13 @@
 
 Auth in PCGL uses CILogon for authentication, COManage for group management, and the pcgl-authz API for authorization (this API uses Open Policy Agent as the permissions engine and calls the COManage API for group information). In this documentation, we use CILogon and COManage interchangeably - they are separately software products on the back end, but from our perspective, it is all one UI.
 
+The authorization service allows PCGL to separately manage OIDC tokens and clients with different token lifetimes for different services.
+
+PCGL services need to register as OIDC clients with CILogon and register with the authorization service. Registration allows authz to:
+* designate actions allowed for users and user groups, based on study
+* designate an OIDC client that will be the issuer of its user tokens
+* allows the authz service to verify that any authz call is coming from a known registered service.
+
 
 ## Authentication
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,35 +1,34 @@
 # Overview of authentication and authorization in PCGL
 
-Auth in PCGL uses CILogon for authentication, COManage for group management, and the pcgl-authz API for authorization (this API uses Open Policy Agent as the permissions engine and calls the COManage API for group information). In this documentation, we use CILogon and COManage interchangeably - they are separately software products on the back end, but from our perspective, it is all one UI. 
+Auth in PCGL uses CILogon for authentication, COManage for group management, and the pcgl-authz API for authorization (this API uses Open Policy Agent as the permissions engine and calls the COManage API for group information). In this documentation, we use CILogon and COManage interchangeably - they are separately software products on the back end, but from our perspective, it is all one UI.
 
-PCGL services need to register as OIDC clients with CILogon and register with the authorization service. 
 
 ## Authentication
 
-All authentication of users in PCGL (except for participants in the participant portal) is via CILogon. 
+All authentication of users in PCGL (except for participants in the participant portal) is via CILogon.
 
-Each PCGL service should register as an OIDC client in CILogon. In the CILogon interface, this is under `Configuration -> OIDC Clients`. 
+Each PCGL service should register as an OIDC client in CILogon. In the CILogon interface, this is under `Configuration -> OIDC Clients`.
 
-All user enrollment is currently either via self-registration (requires approval) or by invitation. We can create multiple enrollment flows under `Configuration -> Enrollment Flows` for managing different kinds of users. See [enrollment](/docs/enrollment.md) for details. 
+All user enrollment is currently either via self-registration (requires approval) or by invitation. We can create multiple enrollment flows under `Configuration -> Enrollment Flows` for managing different kinds of users. See [enrollment](/docs/enrollment.md) for details.
 
-We are using a CILogon deployment that is part of The Alliance subscription - we do not maintain this instance. We are currently only using the test instance - prod is available but not yet configured. Note that PCGL is only one of the Collaborative Organizations in this CILogon deployment. You may see `co:4` at the end of various URLs - we are org #4. 
+We are using a CILogon deployment that is part of The Alliance subscription - we do not maintain this instance. We are currently only using the test instance - prod is available but not yet configured. Note that PCGL is only one of the Collaborative Organizations in this CILogon deployment. You may see `co:4` at the end of various URLs - we are org #4.
 
 External links
-* CILogon website https://www.cilogon.org/ 
-* CILogon docs on registering an OIDC client https://www.cilogon.org/oidc 
-* COManage info https://spaces.at.internet2.edu/display/COmanage/Home 
+* CILogon website https://www.cilogon.org/
+* CILogon docs on registering an OIDC client https://www.cilogon.org/oidc
+* COManage info https://spaces.at.internet2.edu/display/COmanage/Home
 * PCGL CILogon test instance https://registry-test.alliancecan.ca
-* PCGL CILogon prod instance https://registry.alliancecan.ca/registry/ 
+* PCGL CILogon prod instance https://registry.alliancecan.ca/registry/
 
 ## Authorization
 
-The general philosophy for PCGL authentication is that all logic for what users can access what data / services is centrally stored and managed through the pcgl-authz API. This ensures that authorization information is consistent throughout the platform and avoid scenarios where a authorization information has been updated in one service but not another. 
+The general philosophy for PCGL authentication is that all logic for what users can access what data / services is centrally stored and managed through the pcgl-authz API. This ensures that authorization information is consistent throughout the platform and avoid scenarios where a authorization information has been updated in one service but not another.
 
-Services are expected to call the authz API to determine whether a user has the appropriate authorization before releasing / editing data. This is in contract to passing all user authorization in the JWT - we may include more in then token when we implement GA4GH Passports and Visas, but that is a future initiative. 
+Services are expected to call the authz API to determine whether a user has the appropriate authorization before releasing / editing data. This is in contract to passing all user authorization in the JWT - we may include more in then token when we implement GA4GH Passports and Visas, but that is a future initiative.
 
 For specific tasks:
 
-* [service-registration](/docs/service-registration.md) for information on registering a PCGL service with the authorization service 
+* [service-registration](/docs/service-registration.md) for information on registering a PCGL service with the authorization service
 * [authorization](/docs/authorization.md) for using the authorization API to register studies and verify authorization
 * [roles](/docs/roles.md) for management of roles and the currently implemented roles for PCGL
 * [service-verification](/docs/service-verification.md) for implementing service-to-service authorization

--- a/docs/service-registration.md
+++ b/docs/service-registration.md
@@ -1,10 +1,10 @@
-# Service registration 
+# Service registration
 
-In order to enable authorization decisions, PCGL services need to be registered with the authorization service. This registration defines the actions implemented by the service, and generates a UUID for enabling service-to-service authorization.   
+In order to enable authorization decisions, PCGL services need to be registered with the authorization service. This registration defines the actions implemented by the service, and generates a UUID for enabling service-to-service authorization.
 
-The `/service` endpoints can also be used to list all services and get a specific service. See the API spec for details. These endpoints are only available to users that is part of the PCGL Admin group in COManage. 
+The `/service` endpoints can also be used to list all services and get a specific service. See the API spec for details. These endpoints are only available to users that is part of the PCGL Admin group in COManage.
 
-See [service-verification](/docs\/ervice-verification.md) for documentation on making and verifying service-to-service API calls. 
+See [service-verification](/docs\/ervice-verification.md) for documentation on making and verifying service-to-service API calls.
 
 ## API spec
 
@@ -17,11 +17,15 @@ View spec in swagger: https://editor.swagger.io/?url=https://raw.githubuserconte
 Information required for registering a service via a POST to the `/service` endpoint:
 
 * a unique service id (string) - provided by the service
-* a description of the operations considered "read" and "write" for the service, provided as a list of endpoint + http method for each 
+* a description of the operations considered "read" and "write" for the service, provided as a list of endpoint + http method for each
+* the client ID for the OIDC client used by the service
 
 ```
 {
   "service_id": "string",
+  "authorization": {
+    "client_id": "string"
+  },
   "readable": [
     {
       "endpoint": "string",
@@ -37,6 +41,6 @@ Information required for registering a service via a POST to the `/service` endp
 }
 ```
 
-In return, the service receives a UUID to use for [service-to-service verification](/docs/service-verification.md). The service is responsible for saving this UUID securely. This token is not needed to simple call the authz API (but that may change in a future update). 
+In return, the service receives a UUID to use for [service-to-service verification](/docs/service-verification.md). The service is responsible for saving this UUID securely. For most API calls used by services, a service token will be required to securely identify the service; the UUID is needed to create this token.
 
 

--- a/secrets.sh.example
+++ b/secrets.sh.example
@@ -5,7 +5,7 @@ export PCGL_DEBUG_MODE=1
 export PCGL_COID=43
 export PCGL_CORE_API_USER=co_$PCGL_COID.pcgl_authz
 export PCGL_CORE_API_KEY=
-export PCGL_API_URL=https://registry-test.cilogon.org
+export PCGL_API_URL=https://registry-test.alliancecan.ca
 export PCGL_UID=$(id -u)
 
 # Base URL to serve the Authz API over HTTPS


### PR DESCRIPTION
We need to make sure that different registered services can configure their own OIDC clients individually: some services may need long-lived refresh tokens, while others may need short access tokens. To achieve this, the following changes are being implemented:
* registering a service requires the service's associated OIDC client ID
* service tokens can be generated by a service without requiring site admin credentials
* most endpoints require additional headers `X-Service-Token` and `X-Service-Id` so that authz will be able to verify that the user token comes from a registered service and its associated OIDC client.