### PR TITLE
Fix reload_comanage

### DIFF
--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -670,7 +670,7 @@ def get_comanage_groups():
             elif group["name"] == "PCGL:data_submitters":
                 data["ids"]["curator"] = str(group["id"])
                 data["curator"] = group["members"]
-            elif group["name"] == "CO:members:all":
+            elif group["name"] == "CO:members:active":
                 data["ids"]["members"] = str(group["id"])
                 data["members"] = group["members"]
         set_service_store_secret("opa", key="groups", value=json.dumps(data))

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -1,11 +1,7 @@
 import os
-import re
 import requests
-import base64
 import json
 import uuid
-import getpass
-import urllib
 
 
 ## Env vars for most auth methods:

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -635,9 +635,9 @@ def get_user_record(comanage_id=None, oidcsub=None, force=False):
 
 def get_comanage_user(oidcsub=None):
     oidcsub = context["user"]
-    response = requests.get(f"{PCGL_API_URL}/api/co/{PCGL_COID}/core/v1/people", params={"identifier": oidcsub}, auth=(PCGL_CORE_API_USER, PCGL_CORE_API_KEY))
+    response = requests.get(f"{PCGL_API_URL}/registry/api/co/{PCGL_COID}/core/v1/people", params={"identifier": oidcsub}, auth=(PCGL_CORE_API_USER, PCGL_CORE_API_KEY))
     if response.status_code == 200:
-        return response.json()[0], 200
+        return response.json()["0"], 200
     return response.text, response.status_code
 
 

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -693,11 +693,7 @@ def reload_comanage():
     result = []
     # initialize new users:
     try:
-        members_to_initialize = []
-        for i in comanage_groups["members"]:
-            if i not in cached_groups["members"]:
-                members_to_initialize.append(i)
-        for member in members_to_initialize:
+        for member in reversed(comanage_groups["members"]):
             result.append(get_user_record(member))
     except Exception as e:
         return {"error": f"failed to save users: {type(e)} {str(e)}"}, status_code

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -583,7 +583,8 @@ def get_user_record(comanage_id=None, oidcsub=None, force=False):
 
     response, status_code = get_service_store_secret("opa", key=f"users/{comanage_id}")
     if status_code == 200 and not force:
-        return response, status_code
+        if "pcglid" in response:
+            return response, status_code
 
     # either force re-create user or
     # this is a new user: set up the user and the index entry

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -191,6 +191,8 @@ def get_self():
     if status_code == 200:
         if oidcsub in user_index:
             return get_service_store_secret("opa", key=f"users/{user_index[oidcsub]}")
+        # try to see if we can create this record:
+        get_user_record(oidcsub=oidcsub, force=True)
     return {"error": f"could not find user {oidcsub}"}, 404
 
 

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -668,7 +668,7 @@ def get_comanage_groups():
             if group["name"] == "CO:admins":
                 data["ids"]["admin"] = str(group["id"])
                 data["admin"] = group["members"]
-            elif group["name"] == "PCGL:data_submitters":
+            elif group["name"] == "PCGL:site_curators":
                 data["ids"]["curator"] = str(group["id"])
                 data["curator"] = group["members"]
             elif group["name"] == "CO:members:active":

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -233,7 +233,7 @@ def remove_study_authorization(study_id):
 def list_authz_for_user(pcgl_id):
     try:
         if pcgl_id == "me":
-            user_dict, status_code = auth.get_self(connexion.request)
+            user_dict, status_code = auth.get_self()
         else:
             user_dict, status_code = auth.get_user_by_pcglid(pcgl_id)
         if status_code == 200:

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -1,27 +1,13 @@
 import connexion
 import os
-import re
 import urllib.parse
-
 import auth
 import config
-import uuid
 import json
 import requests
 
 
 app = connexion.AsyncApp(__name__)
-
-def get_headers():
-    headers = {}
-    if "Authorization" not in connexion.request.headers:
-        return {"error": "Bearer token required"}, 403
-    if not connexion.request.headers["Authorization"].startswith("Bearer "):
-        return {"error": "Invalid bearer token"}, 403
-    token = connexion.request.headers["Authorization"].split("Bearer ")[1]
-    headers["Authorization"] = "Bearer %s" % token
-    headers["Content-Type"] = "application/json"
-    return headers
 
 
 def handle_token(token):
@@ -29,6 +15,7 @@ def handle_token(token):
     if response.status_code == 200:
         return response.json()
     raise connexion.exceptions.Unauthorized(response.text)
+
 
 # API endpoints
 def get_service_info():

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -239,6 +239,8 @@ def list_authz_for_user(pcgl_id):
         if status_code == 200:
             # sync with COManage:
             auth.get_user_record(comanage_id=user_dict["comanage_id"], force=True)
+            if "pcglid" not in user_dict:
+                return {"error": "User not found in PCGL"}, 404
             result = {
                 "userinfo": {
                     "emails": user_dict["emails"],


### PR DESCRIPTION
Several fixes:
* `get_self` will create a new user record if the user in the token isn't already cached
* There was a bug in one of the COManage Core API calls; I'm not sure how it ever worked before, but it's fixed now
* Instead of caching CO:members:all, which includes pending users, only cache CO:members:active
* If a cached user record doesn't have a pcglid, re-fetch and cache the user record
* reload_comanage will look at all of the entries in CO:members:active, re-fetching and caching any entries that don't have a pcglid

I think that the first fix, the one for get_self, will probably address most of the submission system's needs...I think they are mainly using the /authz/user/me call? But reload_comanage should definitely re-fetch everything now.