### PR TITLE
API tokens need to be exchanged for access tokens

### DIFF
--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -670,7 +670,7 @@ def get_comanage_groups():
             elif group["name"] == "PCGL:data_submitters":
                 data["ids"]["curator"] = str(group["id"])
                 data["curator"] = group["members"]
-            elif group["name"] == "CO:members:all":
+            elif group["name"] == "CO:members:active":
                 data["ids"]["members"] = str(group["id"])
                 data["members"] = group["members"]
         set_service_store_secret("opa", key="groups", value=json.dumps(data))

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -1,11 +1,7 @@
 import os
-import re
 import requests
-import base64
 import json
 import uuid
-import getpass
-import urllib
 
 
 ## Env vars for most auth methods:

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -635,9 +635,9 @@ def get_user_record(comanage_id=None, oidcsub=None, force=False):
 
 def get_comanage_user(oidcsub=None):
     oidcsub = context["user"]
-    response = requests.get(f"{PCGL_API_URL}/api/co/{PCGL_COID}/core/v1/people", params={"identifier": oidcsub}, auth=(PCGL_CORE_API_USER, PCGL_CORE_API_KEY))
+    response = requests.get(f"{PCGL_API_URL}/registry/api/co/{PCGL_COID}/core/v1/people", params={"identifier": oidcsub}, auth=(PCGL_CORE_API_USER, PCGL_CORE_API_KEY))
     if response.status_code == 200:
-        return response.json()[0], 200
+        return response.json()["0"], 200
     return response.text, response.status_code
 
 

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -693,11 +693,7 @@ def reload_comanage():
     result = []
     # initialize new users:
     try:
-        members_to_initialize = []
-        for i in comanage_groups["members"]:
-            if i not in cached_groups["members"]:
-                members_to_initialize.append(i)
-        for member in members_to_initialize:
+        for member in reversed(comanage_groups["members"]):
             result.append(get_user_record(member))
     except Exception as e:
         return {"error": f"failed to save users: {type(e)} {str(e)}"}, status_code

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -583,7 +583,8 @@ def get_user_record(comanage_id=None, oidcsub=None, force=False):
 
     response, status_code = get_service_store_secret("opa", key=f"users/{comanage_id}")
     if status_code == 200 and not force:
-        return response, status_code
+        if "pcglid" in response:
+            return response, status_code
 
     # either force re-create user or
     # this is a new user: set up the user and the index entry

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -191,6 +191,8 @@ def get_self():
     if status_code == 200:
         if oidcsub in user_index:
             return get_service_store_secret("opa", key=f"users/{user_index[oidcsub]}")
+        # try to see if we can create this record:
+        get_user_record(oidcsub=oidcsub, force=True)
     return {"error": f"could not find user {oidcsub}"}, 404
 
 

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -321,7 +321,6 @@ def list_services():
         for service_id in services:
             response, status_code = get_service_store_secret("opa", key=f"services/{service_id}")
             if status_code == 200:
-                response.pop("service_uuid")
                 result.append(response)
     return result, 200
 

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -668,7 +668,7 @@ def get_comanage_groups():
             if group["name"] == "CO:admins":
                 data["ids"]["admin"] = str(group["id"])
                 data["admin"] = group["members"]
-            elif group["name"] == "PCGL:data_submitters":
+            elif group["name"] == "PCGL:site_curators":
                 data["ids"]["curator"] = str(group["id"])
                 data["curator"] = group["members"]
             elif group["name"] == "CO:members:active":

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -330,6 +330,7 @@ def add_service(service_dict):
     service_id = service_dict["service_id"]
 
     updated_service = False
+    service_dict["service_uuid"] = str(uuid.uuid1())
     # list the service in the services index:
     services = []
     response, status_code = get_service_store_secret("opa", key="services")
@@ -337,7 +338,6 @@ def add_service(service_dict):
         services = response["services"]
     if service_id not in services:
         services.append(service_id)
-        service_dict["service_uuid"] = str(uuid.uuid1())
     else:
         updated_service = True
     set_service_store_secret("opa", key="services", value=json.dumps({"services": services}))
@@ -362,11 +362,6 @@ def add_service(service_dict):
         return {"error": "paths not available"}, 500
 
     # write the service into its own store:
-    # if updating, get the uuid:
-    if updated_service:
-        response, status_code = get_service_store_secret("opa", key=f"services/{service_id}")
-        if status_code == 200:
-            service_dict["service_uuid"] = response["service_uuid"]
     response, status_code = set_service_store_secret("opa", key=f"services/{service_id}", value=json.dumps(service_dict))
     return response, status_code
 

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -439,8 +439,11 @@ components:
           description: Information about the OIDC client associated with the service. This information is required to be submitted when registering a service, but will not be returned on GET requests for security reasons.
           required:
             - client_id
+            - client_secret
           properties:
             client_id:
+              type: string
+            client_secret:
               type: string
     StudyAuthorization:
       type: object

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -233,7 +233,7 @@ def remove_study_authorization(study_id):
 def list_authz_for_user(pcgl_id):
     try:
         if pcgl_id == "me":
-            user_dict, status_code = auth.get_self(connexion.request)
+            user_dict, status_code = auth.get_self()
         else:
             user_dict, status_code = auth.get_user_by_pcglid(pcgl_id)
         if status_code == 200:

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -9,12 +9,8 @@ import requests
 
 app = connexion.AsyncApp(__name__)
 
-
-def handle_token(token):
-    response = requests.get(url="https://cilogon.org/oauth2/userinfo", params={"access_token": token}, allow_redirects=False)
-    if response.status_code == 200:
-        return response.json()
-    raise connexion.exceptions.Unauthorized(response.text)
+def handle_token(token, request=None):
+    return auth.handle_token(token, request)
 
 
 # API endpoints

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -1,27 +1,13 @@
 import connexion
 import os
-import re
 import urllib.parse
-
 import auth
 import config
-import uuid
 import json
 import requests
 
 
 app = connexion.AsyncApp(__name__)
-
-def get_headers():
-    headers = {}
-    if "Authorization" not in connexion.request.headers:
-        return {"error": "Bearer token required"}, 403
-    if not connexion.request.headers["Authorization"].startswith("Bearer "):
-        return {"error": "Invalid bearer token"}, 403
-    token = connexion.request.headers["Authorization"].split("Bearer ")[1]
-    headers["Authorization"] = "Bearer %s" % token
-    headers["Content-Type"] = "application/json"
-    return headers
 
 
 def handle_token(token):
@@ -29,6 +15,7 @@ def handle_token(token):
     if response.status_code == 200:
         return response.json()
     raise connexion.exceptions.Unauthorized(response.text)
+
 
 # API endpoints
 def get_service_info():

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -88,7 +88,9 @@ async def add_service():
     service = await connexion.request.json()
     try:
         if auth.is_site_admin(connexion.request):
-            return auth.add_service(service)
+            result, status_code = auth.add_service(service)
+            result.pop("authorization")
+            return result, status_code
         return {"error": "User is not authorized to add services"}, 403
     except auth.UserTokenError as e:
         return {"error": f"{type(e)} {str(e)}"}, 401

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -239,6 +239,8 @@ def list_authz_for_user(pcgl_id):
         if status_code == 200:
             # sync with COManage:
             auth.get_user_record(comanage_id=user_dict["comanage_id"], force=True)
+            if "pcglid" not in user_dict:
+                return {"error": "User not found in PCGL"}, 404
             result = {
                 "userinfo": {
                     "emails": user_dict["emails"],

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -80,7 +80,14 @@ def list_group(group_id):
 def list_services():
     try:
         if auth.is_site_admin(connexion.request):
-            return auth.list_services()
+            services, status_code = auth.list_services()
+            if status_code == 200:
+                for service in services:
+                    if "service_uuid" in service:
+                        service.pop("service_uuid")
+                    if "authorization" in service:
+                        service.pop("authorization")
+            return services, status_code
         return {"error": "User is not authorized to list services"}, 403
     except auth.UserTokenError as e:
         return {"error": f"{type(e)} {str(e)}"}, 401

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       PCGL_USER_KEY: email
       PCGL_ISSUER: ${PCGL_ISSUER}
       PCGL_CLIENT_ID: ${PCGL_CLIENT_ID}
+      PCGL_CLIENT_SECRET: ${PCGL_CLIENT_SECRET}
       PCGL_CORE_API_USER: ${PCGL_CORE_API_USER}
       PCGL_CORE_API_KEY: ${PCGL_CORE_API_KEY}
       PCGL_COID: ${PCGL_COID}
@@ -62,7 +63,7 @@ services:
     cap_add:
       - IPC_LOCK
     command: vault server -config=/vault/config/vault-config.json
-  
+
   # Comment this section out if reverse-proxy is not needed
   caddy:
     # Reverse proxy for routing and data services auth


### PR DESCRIPTION
There was an error in CILogon that I'd been taking advantage of (https://github.com/ncsa/oa4mp/issues/267) that allowed me to get userinfo directly from the refresh token that is passed in to authz calls. They're going to fix it, but it does mean that authz will have to exchange the token internally for the access token in order to get the userinfo.