### PR TITLE
Reload bugs

### DIFF
--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -727,6 +727,9 @@ def reload_comanage():
     if status_code != 200:
         cached_groups = {"members": [], "ids": {}, "index": {}}
 
+    # reset user index
+    delete_service_store_secret("opa", key=f"users/index")
+
     comanage_groups, status_code = get_comanage_groups()
     if status_code == 200:
         comanage_groups, status_code = set_service_store_secret("opa", key="groups", value=json.dumps(comanage_groups))
@@ -736,7 +739,7 @@ def reload_comanage():
     # initialize new users:
     try:
         for member in reversed(comanage_groups["members"]):
-            result.append(get_user_record(member))
+            result.append(get_user_record(member, force=True))
     except Exception as e:
         return {"error": f"failed to save users: {type(e)} {str(e)}"}, status_code
     return {"message": result}, 200

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -651,17 +651,15 @@ def get_user_record(comanage_id=None, oidcsub=None, force=False):
     status_code = 201 # Created
 
     response = user
-
+    errors = []
     # set entries in user index
     if "oidcsub" not in response:
-        response = {"error": f"user {comanage_id} does not have an oidcsub"}
-        status_code = 500
+        errors.append({"error": f"user {comanage_id} does not have an oidcsub"})
     else:
         oidcsub = response["oidcsub"]
         user_index[oidcsub] = str(comanage_id)
     if "pcglid" not in response:
-        response = {"error": f"user {comanage_id} does not have an PCGL ID"}
-        status_code = 500
+        errors.append({"error": f"user {comanage_id} does not have an PCGL ID"})
     else:
         pcglid = response["pcglid"]
         user_index[pcglid] = str(comanage_id)
@@ -674,6 +672,9 @@ def get_user_record(comanage_id=None, oidcsub=None, force=False):
             user_index[email].append(str(comanage_id))
 
     set_service_store_secret("opa", key=f"users/index", value=json.dumps(user_index))
+
+    if len(errors) > 0:
+        return errors, 500
 
     return response, status_code
 

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -237,7 +237,7 @@ def list_authz_for_user(pcgl_id):
             user_dict, status_code = auth.get_user_by_pcglid(pcgl_id)
         if status_code == 200:
             # sync with COManage:
-            auth.get_user_record(comanage_id=user_dict["comanage_id"], force=True)
+            auth.get_user_record(comanage_id=user_dict["comanage_id"])
             if "pcglid" not in user_dict:
                 return {"error": "User not found in PCGL"}, 404
             result = {


### PR DESCRIPTION
I was mishandling the errors for get_user_record when writing out the index entries.
Reloading now also clears the user cache and starts it over again, in case an entry got written in only partially.